### PR TITLE
Test enhancement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ tests: ## Execute test suite and create code coverage report
 	docker run -v $(shell pwd):/app --rm php:7.3 /app/scripts/phpunit /app/tests/
 
 update: ## Update composer packages
-	docker run --rm -v $(shell pwd):/app composer/composer update
+	docker run --rm -v $(shell pwd):/app composer update
 
 bootstrap: ## Install composer
-	docker run --rm -v $(shell pwd):/app composer/composer install
+	docker run --rm -v $(shell pwd):/app composer install

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         }
     ],
     "require": {
+        "php": ">=5.6",
         "aws/aws-sdk-php": "^3.128",
         "guzzlehttp/guzzle": "^6.5"
     }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -4,7 +4,6 @@ namespace Jimdo\Notification\Event;
 
 use PHPUnit\Framework\TestCase;
 
-use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Middleware;


### PR DESCRIPTION
# Changed log
- It seems that the official Docker image name of `composer` is changed. Using `docker pull composer:latest` instead.
- According to the `composer.lock` file, adding `php-5.6` version requirement for this package.
- Removing the `use GuzzleHttp\Client as HttpClient;` namespace on `ClientTest` class because it's unused.
